### PR TITLE
Switch to using my containers for ADS-B Exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ ADS-B data from dump1090-docker can be
   1. Run [docker-piaware](https://github.com/wnagele/docker-piaware).
 
      ```shell
-     docker run --rm -d --link dump1090:beast --name piaware [--env FEEDER_ID=<feeder id>] wnagele/piaware <flightaware user> <flightaware password>
+     docker run --rm -d --link dump1090:beast --name piaware \
+     [--env FEEDER_ID=<feeder id>] wnagele/piaware <flightaware user> <flightaware password>
      ```
 
      Note, if you're running on a Raspberry Pi or a non-x86 machine, the
@@ -132,14 +133,29 @@ of [adsbexchange-docker](https://hub.docker.com/search?q=marcelstoer%2Fadsbexcha
   1. Run [adsbexchange-docker-feed](https://github.com/marcelstoer/adsbexchange-docker).
 
      ```shell
-     docker run --rm -d -e "INPUT=decoder:30005" —link dump1090:decoder --name adsbexchange-feed marcelstoer/adsbexchange-docker-feed:latest
+     docker run --rm -d -e "INPUT=decoder:30005" --link dump1090:decoder \
+     --name adsbexchange-feed marcelstoer/adsbexchange-docker-feed:latest
      ```
-  1. Run [adsbexchange-docker-mlat](https://github.com/marcelstoer/adsbexchange-docker).
 
-     **Note**: make sure you replace the dummy values in the command below with your effective values
+  1. Optionally run [adsbexchange-docker-mlat](https://github.com/marcelstoer/adsbexchange-docker).
+
+     Notes:
+
+     1. make sure you replace the dummy values in the command below with your
+     effective values
+     1. ADS-B Exchange ask you to enter the receiver GPS coordinates for
+     [MLAT](https://en.wikipedia.org/wiki/Multilateration) with 5-digit precision
+     1. Even though you are giving away the exact receiver position ASD-B
+     Exchange will never disclose this information. To protect the privacy of
+     the feeders, the receiver locations displayed on their maps (e.g. for
+     [Central Europe](https://adsbexchange.com/coverage-4B/)) are approximate
+     only.
 
      ```shell
-     docker run --rm -d -e "INPUT=decoder:30005" -e "MLAT_RESULTS=decoder:30104" -e "RECEIVER_LATITUDE=nn.mmmmm" -e "RECEIVER_LONGITUDE=nn.mmmmm" -e "RECEIVER_ALTITUDE=nnnn" -e "RECEIVER_NAME=my-fantastic-ADS-B-receiver" --link dump1090:decoder --name adsbexchange-mlat marcelstoer/adsbexchange-docker-mlat:latest
+     docker run --rm -d -e "INPUT=decoder:30005" -e "MLAT_RESULTS=decoder:30104" \
+     -e "RECEIVER_LATITUDE=nn.mmmmm" -e "RECEIVER_LONGITUDE=nn.mmmmm" \
+     -e "RECEIVER_ALTITUDE=nnnn" -e "RECEIVER_NAME=my-fantastic-ADS-B-receiver" \
+     --link dump1090:decoder --name adsbexchange-mlat marcelstoer/adsbexchange-docker-mlat:latest
      ```
 
 * Using docker-compose
@@ -148,7 +164,7 @@ of [adsbexchange-docker](https://hub.docker.com/search?q=marcelstoer%2Fadsbexcha
      [adsbexchange-docker](https://github.com/marcelstoer/adsbexchange-docker) containers and
      dump1090.
 
-     If using docker-compose, you must specify your MLAT properties in 
+     If using docker-compose, you must specify your MLAT properties in
      [adsbexchange\_mlat\_properties.txt](https://github.com/jeanralphaviles/dump1090-docker/blob/master/adsbexchange_mlat_properties.txt).
 
      ```shell

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ docker build -t jraviles/dump1090:latest .
 
 ## Skyview
 
-dump1090-docker exposes a webserver on port 8080 serving up Piaware Skyview.
+dump1090-docker exposes a webserver on port 8080 serving up PiAware Skyview.
 Skyview is a web portal for viewing flights your receiver is picking up on a
 map in real time.
 
@@ -123,46 +123,46 @@ more documentation.
 
 ADS-B data from dump1090-docker can be
 [fed to ADS-B Exchange](https://www.adsbexchange.com/how-to-feed) with the help
-of [docker-adsbexchange](https://github.com/webmonkey/docker-adsbexchange).
+of [adsbexchange-docker](https://hub.docker.com/search?q=marcelstoer%2Fadsbexchange&type=image) images.
 
 * Using vanilla Docker
 
   1. Ensure dump1090 is running.
 
-  1. Fetch
-     [docker-adsbexchange](https://github.com/webmonkey/docker-adsbexchange)
-     and build Docker image.
+  1. Run [adsbexchange-docker-feed](https://github.com/marcelstoer/adsbexchange-docker).
 
      ```shell
-     git clone https://github.com/webmonkey/docker-adsbexchange.git
-     cd docker-adsbexchange
-     docker build -t webmonkey/adsbexchange:latest .
+     docker run --rm -d -e "INPUT=decoder:30005" —link dump1090:decoder --name adsbexchange-feed marcelstoer/adsbexchange-docker-feed:latest
      ```
+  1. Run [adsbexchange-docker-mlat](https://github.com/marcelstoer/adsbexchange-docker).
 
-  1. Run [docker-adsbexchange](https://github.com/webmonkey/docker-adsbexchange).
+     **Note**: make sure you replace the dummy values in the command below with your effective values
 
      ```shell
-     docker run --rm -d --link dump1090:decoder --name adsb-exchange [--env RECEIVER_PORT=<port>] webmonkey/adsbexchange:latest
+     docker run --rm -d -e "INPUT=decoder:30005" -e "MLAT_RESULTS=decoder:30104" -e "RECEIVER_LATITUDE=nn.mmmmm" -e "RECEIVER_LONGITUDE=nn.mmmmm" -e "RECEIVER_ALTITUDE=nnnn" -e "RECEIVER_NAME=my-fantastic-ADS-B-receiver" --link dump1090:decoder --name adsbexchange-mlat marcelstoer/adsbexchange-docker-mlat:latest
      ```
 
 * Using docker-compose
 
   1. Start
-     [docker-adsbexchange](https://github.com/webmonkey/docker-adsbexchange) and
+     [adsbexchange-docker](https://github.com/marcelstoer/adsbexchange-docker) containers and
      dump1090.
 
+     If using docker-compose, you must specify your MLAT properties in 
+     [adsbexchange\_mlat\_properties.txt](https://github.com/jeanralphaviles/dump1090-docker/blob/master/adsbexchange_mlat_properties.txt).
+
      ```shell
-     docker-compose up -d adsb-exchange dump1090
+     docker-compose up -d dump1090 adsbexchange-feed adsbexchange-mlat
      ```
 
-[docker-adsbexchange](https://github.com/webmonkey/docker-adsbexchange)
+[adsbexchange-docker](https://github.com/marcelstoer/adsbexchange-docker)
 supports
 [ADS-B Exchange custom feeds](https://www.adsbexchange.com/how-to-feed/custom-feed-how-to).
 To feed data to a custom feed, set the **RECEIVER\_PORT** to that of a feed you
-have claimed. If unset, docker-adsbexchange will feed the default port: 30005\.
+have claimed. If unset, adsbexchange-docker will feed the default port: 30005\.
 To set **RECEIVER_PORT** using docker-compose you must add an
 [environment section](https://docs.docker.com/compose/compose-file/#environment) to
-adsb-exchange's service in
+adsbexchange-feed's service in
 [docker-compose.yml](https://github.com/jeanralphaviles/dump1090-docker/blob/master/docker-compose.yml).
 
 ## Feeding live flight data to ADSBHub

--- a/adsbexchange_mlat_properties.txt
+++ b/adsbexchange_mlat_properties.txt
@@ -1,0 +1,7 @@
+# add the geo coordinates of your ADS-B reeiver
+RECEIVER_LATITUDE=**.*****
+RECEIVER_LONGITUDE=**.******
+# meters above sea level
+RECEIVER_ALTITUDE=***
+# identify your receiver with something unique
+RECEIVER_NAME=XXX***XXX

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,22 @@ services:
       - BEAST_PORT_30005_TCP_ADDR=dump1090
     restart: unless-stopped
 
-  adsb-exchange:
-    build:
-      context: 'https://github.com/webmonkey/docker-adsbexchange.git'
+  adsbexchange-feed:
+    environment:
+      - 'INPUT=decoder:30005'
     links:
-      - dump1090:decoder
+      - 'dump1090:decoder'
+    image: marcelstoer/adsbexchange-docker-feed
+    restart: unless-stopped
+
+  adsbexchange-mlat:
+    env_file: 'adsbexchange_mlat_properties.txt'
+    environment:
+      - 'INPUT=decoder:30005'
+      - 'MLAT_RESULTS=decoder:30104'
+    links:
+      - 'dump1090:decoder'
+    image: marcelstoer/adsbexchange-docker-mlat
     restart: unless-stopped
 
   adsbhub:


### PR DESCRIPTION
I feel that using my images offers some material benefit over using the simple feed image from webmonkey.

- MLAT support
- Both beast and MLAT run scripts are built upon a retry mechanism. That is essential particularly for MLAT as ADSBX resets the connections once every 24h.