### PR TITLE
pass in the FA credentials for the docker cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ receiver.
 * Using vanilla Docker
 
   ```shell
-  docker run --rm -d --device /dev/bus/usb --name dump1090 -p 8080:8080 jraviles/dump1090:latest
+  docker run --rm -d --device /dev/bus/usb --env-file flightaware_credentials.txt --name dump1090 -p 8080:8080 jraviles/dump1090:latest
   ```
 
 * Using docker-compose


### PR DESCRIPTION
The text file is included in Compose, but not in the 'raw' version. Including here, if nothing else it's a hint on how it works.