### PR TITLE
add github link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ deployment.
 | [ADSBHub](http://www.adsbhub.org)                |
 
 Visit dump1090-docker on
-[Docker Hub](https://hub.docker.com/r/jraviles/dump1090) :whale:.
+[Docker Hub](https://hub.docker.com/r/jraviles/dump1090) :whale: or [Github](https://github.com/jeanralphaviles/dump1090-docker/).
+
 
 ## Usage
 


### PR DESCRIPTION
Yes, we're in the repo right now, but the text on dockerhub doesn't  include any link back to github, and your usernames are different.